### PR TITLE
Add a command option to set environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The environment of launched processes can now be customized using the
+  `SetEnvironment` variant of `CommandOpt`.
+
 ## v1.6.0 - 2024-02-12
 
 - Shellout now supports `gleam_stdlib` v1.0.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "shellout"
-version = "1.6.0"
+version = "1.7.0-dev"
 description = "A Gleam library for cross-platform shell operations"
 licences = ["Apache-2.0"]
 gleam = ">= 0.34.0"

--- a/src/shellout_ffi.erl
+++ b/src/shellout_ffi.erl
@@ -1,8 +1,8 @@
 -module(shellout_ffi).
 
--export([os_command/4, os_exit/1, os_which/1, start_arguments/0]).
+-export([os_command/5, os_exit/1, os_which/1, start_arguments/0]).
 
-os_command(Command, Args, Dir, Opts) ->
+os_command(Command, Args, Dir, Opts, EnvBin) ->
     Which =
         case os_which(Command) of
             {error, _} ->
@@ -17,10 +17,18 @@ os_command(Command, Args, Dir, Opts) ->
             {ok, Executable} ->
                 ExecutableChars = binary_to_list(Executable),
                 LetBeStdout = maps:get(let_be_stdout, Opts, false),
+                FromBin = fun({Name, Val}) ->
+                    {
+                        binary_to_list(Name),
+                        unicode:characters_to_list(Val, file:native_name_encoding())
+                    }
+                end,
+                Env = lists:map(FromBin, EnvBin),
                 PortSettings = lists:merge([
                     [
                         {args, Args},
                         {cd, Dir},
+                        {env, Env},
                         eof,
                         exit_status,
                         hide,

--- a/test/shellout_test.gleam
+++ b/test/shellout_test.gleam
@@ -2,7 +2,7 @@ import gleam/dict
 import gleam/string
 import gleeunit
 import gleeunit/should
-import shellout.{type Lookups, LetBeStderr, LetBeStdout}
+import shellout.{type Lookups, LetBeStderr, LetBeStdout, SetEnvironment}
 
 pub fn main() {
   gleeunit.main()
@@ -70,6 +70,49 @@ pub fn command_test() {
   |> should.equal(2)
   message
   |> should.not_equal("")
+}
+
+pub fn environment_test() {
+  let print = fn(env, message) {
+    shellout.command(
+      run: "sh",
+      with: ["-c", string.concat(["echo -n ", message])],
+      in: ".",
+      opt: [SetEnvironment(env)],
+    )
+  }
+
+  print([#("TEST_1", "1"), #("TEST_2", "2")], "$TEST_1 $TEST_2 3")
+  |> should.equal(Ok("1 2 3"))
+
+  print([#("PATH", "/bin:/ビン")], "$PATH")
+  |> should.equal(Ok("/bin:/ビン"))
+
+  shellout.command(
+    run: "sh",
+    with: ["-c", string.concat(["echo -n $TEST_3 $TEST_2 $TEST_1"])],
+    in: ".",
+    opt: [
+      SetEnvironment([#("TEST_1", "3"), #("TEST_3", "3")]),
+      SetEnvironment([#("TEST_1", "1"), #("TEST_2", "2")]),
+    ],
+  )
+  |> should.equal(Ok("3 2 1"))
+
+  let test_var = fn(env, var) {
+    shellout.command(
+      run: "sh",
+      with: ["-c", string.concat(["test -n \"$", var, "\""])],
+      in: ".",
+      opt: [SetEnvironment(env)],
+    )
+  }
+
+  test_var([], "HOME")
+  |> should.be_ok
+
+  test_var([#("HOME", "")], "HOME")
+  |> should.be_error
 }
 
 @target(erlang)


### PR DESCRIPTION
Adds `SetEnvironment(List(#(String, String)))` to `CommandOpt`, where the contents of the list are key-value pairs to set as environment variables in the child process. I tested across erlang, node, and deno.