### PR TITLE
Fix FFI compatibility with gleam_stdlib export changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,36 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26"
+          otp-version: "28"
           rebar3-version: "3"
-          gleam-version: "1.0.0-rc1"
+          gleam-version: "1.13.0"
 
-      - uses: denoland/setup-deno@v1
+      - uses: denoland/setup-deno@v2
         with:
-          deno-version: "v1.x"
+          deno-version: "v2.x"
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.deno
             ~/.cache/deno
           key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: WhatsApp/erlfmt
           path: _temp/erlfmt
 
       - id: cache-erlfmt
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /usr/local/bin/erlfmt
           key: ${{ runner.os }}-erlfmt-${{ hashFiles('_temp/erlfmt/src/erlfmt.app.src') }}
@@ -52,7 +52,7 @@ jobs:
           mv _build/release/bin/erlfmt /usr/local/bin/
 
       - id: cache-gleam
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: build/packages
           key: ${{ runner.os }}-gleam-${{ hashFiles('manifest.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: "v2.x"
+          deno-version: "v1.x"
 
       - uses: actions/cache@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Shellout now supports `gleam_stdlib` v0.68.
+- Shellout now requires Gleam v1.13 or later.
+
 ## v1.7.0 - 2024-03-22
 
 - The environment of launched processes can now be customized using the

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,8 +1,8 @@
 name = "shellout"
-version = "1.7.0"
+version = "1.8.0-dev"
 description = "A Gleam library for cross-platform shell operations"
 licences = ["Apache-2.0"]
-gleam = ">= 0.34.0"
+gleam = ">= 1.13.0"
 
 [repository]
 repo = "shellout"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 
 packages = [
   { name = "gleam_stdlib", version = "0.47.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3B22D46743C46498C8355365243327AC731ECD3959216344FA9CF9AD348620AC" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleeunit", version = "1.3.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "A7DD6C07B7DA49A6E28796058AA89E651D233B357D5607006D70619CD89DAAAB" },
 ]
 
 [requirements]

--- a/src/shellout_ffi.mjs
+++ b/src/shellout_ffi.mjs
@@ -4,8 +4,12 @@ import { delimiter as pathDelimiter, join as pathJoin } from "node:path";
 import process from "node:process";
 import { get as dict_get } from "../gleam_stdlib/gleam/dict.mjs";
 import { map_error } from "../gleam_stdlib/gleam/result.mjs";
-import { Result$Ok, Result$Error, Result$isOk, toList } from "./gleam.mjs";
-import { CommandOpt$LetBeStderr, CommandOpt$LetBeStdout, CommandOpt$OverlappedStdio } from "./shellout.mjs";
+import { Result$Error, Result$isOk, Result$Ok, toList } from "./gleam.mjs";
+import {
+  CommandOpt$LetBeStderr,
+  CommandOpt$LetBeStdout,
+  CommandOpt$OverlappedStdio,
+} from "./shellout.mjs";
 
 const Nil = undefined;
 const Signals = {


### PR DESCRIPTION
The latest stdlib [reworked Dicts quite a bit](https://github.com/gleam-lang/stdlib/pull/880), and the JS FFI in shellout was relying on internals to function. This PR updates the JS FFI to use the API's documented in the [externals guide](https://gleam.run/documentation/externals/#Gleam-data-in-JavaScript). The error I was getting was:

```
An unexpected error occurred:

  //js(TypeError: map.get is not a function)
```